### PR TITLE
The plugin .so is 1600x as big as it should be

### DIFF
--- a/myplugin.go
+++ b/myplugin.go
@@ -1,4 +1,4 @@
-package main
+package muchsmaller
 
 func Add(x, y int) int {
     return x+y


### PR DESCRIPTION
Re: https://jeremywho.com/go-1.8---plugins/

The reason the plugin is so big is because it was built as package `main` - if you change the package name to anything else it comes out ~1kB